### PR TITLE
this fixes mess of the .biicode folder

### DIFF
--- a/shell/bii.py
+++ b/shell/bii.py
@@ -28,9 +28,9 @@ from biicode.client.workspace.user_cache import UserCache
 class Bii(object):
     '''Entry point class for bii executable'''
 
-    def __init__(self, user_io, current_folder, user_home_folder):
+    def __init__(self, user_io, current_folder, user_biicode_folder):
         self.user_io = user_io
-        self.bii_paths = BiiPaths(current_folder, user_home_folder)
+        self.bii_paths = BiiPaths(current_folder, user_biicode_folder)
         self.user_cache = UserCache(self.bii_paths.user_bii_home)
         toolcatalog = ToolCatalog(BiiCommand, tools=[CPPToolChain,
                                                      RPiToolChain,
@@ -89,11 +89,11 @@ def run_main(args, user_io=None, current_folder=None, user_folder=None, biiapi_c
         current_folder = current_folder or os.getcwd()
         user_io = user_io or create_user_io(biicode_folder)
 
-        bii = Bii(user_io, current_folder, user_folder)
+        bii = Bii(user_io, current_folder, biicode_folder)
 
         # Update manager doesn't need proxy nor authentication to call get_server_info
         biiapi_client = biiapi_client or bii.biiapi
-        updates_manager = get_updates_manager(biiapi_client, user_folder)
+        updates_manager = get_updates_manager(biiapi_client, biicode_folder)
 
         try:  # Check for updates
             updates_manager.check_for_updates(bii.user_io.out)

--- a/workspace/bii_paths.py
+++ b/workspace/bii_paths.py
@@ -18,7 +18,6 @@ BIN_DIR = 'bin'
 BII_DIR = 'bii'
 CMAKE_DIR = 'cmake'
 BII_HIVE_DB = '.hive.db'
-USER_BII_HOME = '.biicode'
 LIB_DIR = "lib"
 AUTO_ROOT_BLOCK = "auto-root-block"
 ROOT_BLOCK = "root-block"
@@ -87,17 +86,17 @@ def get_biicode_env_folder_path():
 class BiiPaths(object):
     """ Contains all the path references for a biicode running instance
     """
-    def __init__(self, current_dir, user_home):
+    def __init__(self, current_dir, user_biicode_folder):
         """ current_dir: The getcwd() of execution
         user_home: the place where the local.db cache and all the user stuff lives,
                    if None, it will be computed as os.path.expanduser("~")
         """
-        assert user_home
+        assert user_biicode_folder
         assert current_dir
         self._project_root = None  # lazy computed and cached
         self._current_layout = None  # lazy loaded from file and cached
         self._current_dir = current_dir  # The dir user runs the command from
-        self._user_home = user_home
+        self._user_home = user_biicode_folder
 
     @property
     def current_dir(self):
@@ -113,11 +112,7 @@ class BiiPaths(object):
         """ user biicode home is .biicode, is independent of project
         location
         """
-        # FIXME: Dirty hack to the problem of different origins for self._user_home
-        # Should be fixed in last commit, but to be checked
-        if os.path.basename(self._user_home) == USER_BII_HOME:
-            return self._user_home
-        return os.path.join(self._user_home, USER_BII_HOME)
+        return self._user_home
 
     @property
     def cmake_path_file(self):


### PR DESCRIPTION
There is a bug right now in 2.8, and .remote_version_info is created in the user home, not in user/.biicode.

This fixes it, and clears a small legacy mess with the paths. The tests repo has been already updated accordingly.
